### PR TITLE
lock nvim-lspconfig until gopls is fixed

### DIFF
--- a/nvim/lua/plugins/nvim-lspconfig.lua
+++ b/nvim/lua/plugins/nvim-lspconfig.lua
@@ -1,0 +1,6 @@
+return {
+  {
+    "neovim/nvim-lspconfig",
+    commit = "80861dc",
+  },
+}


### PR DESCRIPTION
`nvim-lspconfig` has issues with `gopls` on Linux where it is unable to correctly find the mod_cache after [this PR](https://github.com/neovim/nvim-lspconfig/pull/2673). Lock `nvim-lspconfig` to the commit prior until it is fully addressed.